### PR TITLE
Add flag to specify a bare token

### DIFF
--- a/bin/autosign
+++ b/bin/autosign
@@ -42,6 +42,9 @@ command :generate do |c|
   c.desc 'Generate a reusable token; default is to generate one-time tokens'
   c.switch [:r, :reusable]
 
+  c.desc 'Output only a bare token without the surrounding csr_attributes template'
+  c.switch [:b, :bare]
+
   c.desc 'autosign token validity period'
   c.default_value '7200'
   c.arg_name 'seconds'
@@ -58,12 +61,17 @@ command :generate do |c|
 
     help_now!('validfor setting must be an positive integer number of seconds') if !/\A\d+\z/.match(options['validfor'].to_s)
     token = Autosign::Token.new(certname, options['reusable'], options['validfor'].to_i, Socket.gethostname.to_s, global_options['secret'])
-    @logger.info "generated token for: " + certname
-    puts "Autosign token for: " + token.certname + ", valid until: " + Time.at(token.validto).to_s
-    puts "To use the token, put the following in ${puppet_confdir}/csr_attributes.yaml prior to running puppet agent for the first time:"
-    puts ""
-    puts "custom_attributes:"
-    puts "  challengePassword: \"#{token.sign.to_s}\""
+
+    if options[:bare]
+      puts token.sign.to_s
+    else
+      @logger.info "generated token for: " + certname
+      puts "Autosign token for: " + token.certname + ", valid until: " + Time.at(token.validto).to_s
+      puts "To use the token, put the following in ${puppet_confdir}/csr_attributes.yaml prior to running puppet agent for the first time:"
+      puts ""
+      puts "custom_attributes:"
+      puts "  challengePassword: \"#{token.sign.to_s}\""
+    end
   end
 end
 

--- a/features/autosign.feature
+++ b/features/autosign.feature
@@ -19,6 +19,23 @@ Feature: Generate autosign key
      And the output should contain "valid until"
      And the exit status should be 0
 
+  Scenario: Generate new token using the --bare flag
+    Given a pre-shared key of "secret"
+      And a hostname of "foo.example.com"
+      And a file named "autosign.conf" with:
+      """
+      ---
+      jwt_token:
+        validity: '7200'
+        secret: 'secret'
+      """
+    When I run `chmod 600 autosign.conf`
+     And I run `autosign --config autosign.conf generate --bare foo.example.com`
+    Then the output should be a JSON web token
+     And the output should not contain "Autosign token for: foo.example.com"
+     And the output should not contain "valid until"
+     And the exit status should be 0
+
   Scenario: Generate new reusable token
     Given a pre-shared key of "secret"
       And a hostname of "foo.example.com"


### PR DESCRIPTION
Provide an option to generate only a bare token, rather than the full csr attributes yaml file.

This addresses https://github.com/danieldreier/autosign/issues/8

@dhoile will this provide the functionality you need? Example output:

```
bundle exec bin/autosign generate --bare foo.example.com
eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJkYXRhIjoie1wiY2VydG5hbWVcIjpcImZvby5leGFtcGxlLmNvbVwiLFwicmVxdWVzdGVyXCI6XCJEYW5pZWxzLU1hY
0Jvb2subG9jYWxcIixcInJldXNhYmxlXCI6ZmFsc2UsXCJ2YWxpZGZvclwiOjcyMDAsXCJ1dWlkXCI6XCJiNmQyYmNmYS1hYTVkLTQ2ZmQtYjVhZS1hMzQwZTQwMjhmMWN
cIn0iLCJleHAiOiIxNDQ0Mjg2NDIzIn0.kqZBAHqeRFezOcBE06TkuRyuL28OnXL2BDc8m7Oabe38jjCOfNDo-Y70l9RaaGlErx6hBk_DnyvGayIBMc5u_g
```

If this does what you need I can merge and push a new release to rubygems, maybe after I fix another bug or two unless this is urgent for you.