### PR TITLE
(issue #15) do not print help text using --quiet

### DIFF
--- a/bin/autosign
+++ b/bin/autosign
@@ -66,9 +66,11 @@ command :generate do |c|
       puts token.sign.to_s
     else
       @logger.info "generated token for: " + certname
-      puts "Autosign token for: " + token.certname + ", valid until: " + Time.at(token.validto).to_s
-      puts "To use the token, put the following in ${puppet_confdir}/csr_attributes.yaml prior to running puppet agent for the first time:"
-      puts ""
+      unless global_options[:quiet]
+        puts "Autosign token for: " + token.certname + ", valid until: " + Time.at(token.validto).to_s
+        puts "To use the token, put the following in ${puppet_confdir}/csr_attributes.yaml prior to running puppet agent for the first time:"
+        puts ""
+      end
       puts "custom_attributes:"
       puts "  challengePassword: \"#{token.sign.to_s}\""
     end


### PR DESCRIPTION
When autosign --quiet is used, we do not want to print the help text surrounding the templated autosign.yaml.

Without this change, we can't easily pipe the output of the autosign generate command to an autosign.yaml without processing.

This should address https://github.com/danieldreier/autosign/issues/15