### PR TITLE
Decrement version.rb to 0.1.1

### DIFF
--- a/lib/autosign/version.rb
+++ b/lib/autosign/version.rb
@@ -1,3 +1,3 @@
 module Autosign
-  VERSION = '0.1.2'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
0.1.1 was never published, so we should publish 0.1.1 instead of 0.1.2.

0.1.2 did not publish to ruby gems automatically because it wasn't tagged.