### PR TITLE
Add date and time information to log messages

### DIFF
--- a/lib/autosign/config.rb
+++ b/lib/autosign/config.rb
@@ -36,7 +36,7 @@ module Autosign
     # @return [Autosign::Config] instance of the Autosign::Config class
     def initialize(settings_param = {})
       # set up logging
-      @log = Logging.logger['Autosign::Config']
+      @log = Logging.logger('Autosign::Config', {:date_pattern => '%Y-%m-%dT%H:%M:%S.%s'})
       @log.debug "initializing Autosign::Config"
       # validate parameter
       raise 'settings is not a hash' unless settings_param.is_a?(Hash)

--- a/lib/autosign/decoder.rb
+++ b/lib/autosign/decoder.rb
@@ -9,7 +9,7 @@ module Autosign
     # @param csr[String] X509 format CSR
     # @return [Hash] hash containing :challenge_password and :common_name keys
     def self.decode_csr(csr)
-      @log = Logging.logger['Autosign::Decoder']
+      @log = Logging.logger('Autosign::Decoder', {:date_pattern => '%Y-%m-%dT%H:%M:%S.%s'})
       @log.debug "decoding CSR"
 
       begin

--- a/lib/autosign/journal.rb
+++ b/lib/autosign/journal.rb
@@ -15,7 +15,7 @@ module Autosign
     # @param settings [Hash] config settings for the new journal instance
     # @return [Autosign::Journal] instance of the Autosign::Journal class
     def initialize(settings = {})
-      @log = Logging.logger['Autosign::Journal']
+      @log = Logging.logger('Autosign::Journal', {:date_pattern => '%Y-%m-%dT%H:%M:%S.%s'})
       @log.debug "initializing Autosign::Journal"
       @settings = settings
       fail unless setup

--- a/lib/autosign/token.rb
+++ b/lib/autosign/token.rb
@@ -33,7 +33,7 @@ module Autosign
     # @return [Autosign::Config] instance of the Autosign::Config class
     def initialize(certname, reusable=false, validfor=7200, requester, secret)
       # set up logging
-      @log = Logging.logger['Autosign::Token']
+      @log = Logging.logger('Autosign::Token', {:date_pattern => '%Y-%m-%dT%H:%M:%S.%s'})
       @log.debug "initializing"
 
       @validfor  = validfor
@@ -56,7 +56,7 @@ module Autosign
     # @param hmac_secret [String] Password that the token was (hopefully) originally signed with.
     # @return [True, False] returns true if the token can be validated, or false if the token cannot be validated.
     def self.validate(requested_certname, token, hmac_secret)
-      @log = Logging.logger['Autosign::Token.validate']
+      @log = Logging.logger('Autosign::Token.validate', {:date_pattern => '%Y-%m-%dT%H:%M:%S.%s'})
       @log.debug "attempting to validate token"
       @log.info "attempting to validate token for: #{requested_certname.to_s}"
       errors = []

--- a/lib/autosign/validator.rb
+++ b/lib/autosign/validator.rb
@@ -92,7 +92,7 @@ module Autosign
     # @param raw_csr [String] the encoded X509 certificate signing request, as received by the autosign policy executable
     # @return [True, False] return true if the certificate should be signed, and false if it cannot be validated
     def self.any_validator(challenge_password, certname, raw_csr)
-      @log = Logging.logger[self.name]
+      @log = Logging.logger(self.name, {:date_pattern => '%Y-%m-%dT%H:%M:%S.%s'})
       # iterate over all known validators and attempt to validate using them
       results_by_validator = {}
       results = self.descendants.map {|c|
@@ -120,7 +120,7 @@ module Autosign
     # this is automatically called when the class is initialized; do not
     # override it in child classes.
     def start_logging
-      @log = Logging.logger["Autosign::Validator::" + self.name.to_s]
+      @log = Logging.logger("Autosign::Validator::" + self.name.to_s, {:date_pattern => '%Y-%m-%dT%H:%M:%S.%s'})
       @log.debug "starting autosign validator: " + self.name.to_s
     end
 


### PR DESCRIPTION
Without this change, there is no reference of time in the log messages
that are output by the autosign system.  This work adds a basic date
time information to the log message.