### PR TITLE
Fixed json conflict with ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.0.0
   - 2.1.5
   - 2.2.2
+  - 2.3.0
 deploy:
   provider: rubygems
   api_key:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       deep_merge (~> 1)
       gli (~> 2)
       iniparse (~> 1)
-      json (~> 1)
+      json (>= 1)
       jwt (~> 1)
       logging (~> 2)
       require_all (~> 1)
@@ -46,7 +46,7 @@ GEM
     cucumber-core (1.3.1)
       gherkin3 (~> 3.1.0)
     cucumber-wire (0.0.1)
-    deep_merge (1.0.1)
+    deep_merge (1.1.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.25)
@@ -56,7 +56,7 @@ GEM
       CFPropertyList (~> 2.2.6)
     ffi (1.9.10)
     gherkin3 (3.1.2)
-    gli (2.13.4)
+    gli (2.14.0)
     hiera (1.3.4)
       json_pure
     http-cookie (1.0.2)
@@ -64,9 +64,9 @@ GEM
     iniparse (1.4.2)
     json (1.8.3)
     json_pure (1.8.3)
-    jwt (1.5.2)
+    jwt (1.5.6)
     little-plugger (1.1.4)
-    logging (2.0.0)
+    logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.8.2)
@@ -116,7 +116,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    yard (0.8.7.6)
+    yard (0.9.5)
 
 PLATFORMS
   ruby
@@ -131,3 +131,6 @@ DEPENDENCIES
   rake (~> 10)
   rdoc (~> 4)
   rspec (~> 3)
+
+BUNDLED WITH
+   1.13.6

--- a/autosign.gemspec
+++ b/autosign.gemspec
@@ -28,7 +28,7 @@ spec = Gem::Specification.new do |s|
   s.add_runtime_dependency('jwt','~> 1')
   s.add_runtime_dependency('iniparse','~> 1')
   s.add_runtime_dependency('logging', '~> 2')
-  s.add_runtime_dependency('json', '~> 1')
+  s.add_runtime_dependency('json', '>=1')
   s.add_runtime_dependency('deep_merge', '~> 1')
   s.add_runtime_dependency('require_all', '~> 1')
   s.add_runtime_dependency('yard', '~> 0.8')


### PR DESCRIPTION
This plugin was failing on hosts with ruby 2.3:
```
Error: Could not autoload puppet/parser/functions/gen_autosign_token: Unable to activate autosign-0.1.2, because json-2.0.2 conflicts with json (~> 1)
```
Relaxing that constrained helped and it seems like all the tests are still running fine.