### PR TITLE
Fix decoder error when no challengePassword in csr

### DIFF
--- a/lib/autosign/decoder.rb
+++ b/lib/autosign/decoder.rb
@@ -23,8 +23,12 @@ module Autosign
       end
 
       # extract challenge password
-
-      challenge_password = csr.attributes.find { |a| a.oid == 'challengePassword' }.value.value.first.value.to_s
+      challenge_attr = csr.attributes.find { |a| a.oid == 'challengePassword' }
+      challenge_password = if challenge_attr
+                             challenge_attr.value.value.first.value.to_s
+                           else
+                             nil
+                           end
 
       # extract common name
       common_name = /^\/CN=(\S*)$/.match(csr.subject.to_s)[1]

--- a/spec/specs/decoder_spec.rb
+++ b/spec/specs/decoder_spec.rb
@@ -3,14 +3,22 @@ require 'spec_helper'
 context Autosign::Decoder do
   describe '.decode_csr' do
     let(:csr) { File.read(File.join('fixtures', 'i-7672fe81.pem')) }
+
     it 'Accepts a CSR as the parameter' do
       expect { Autosign::Decoder.decode_csr(csr) }.to_not raise_error
     end
+
     it 'Extracts the challenge_password and common_name from a CSR' do
       expect(Autosign::Decoder.decode_csr(csr)).to eq({:challenge_password=>"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJkYXRhIjoie1wiY2VydG5hbWVcIjpcImktNzY3MmZlODFcIixcInJlcXVlc3RlclwiOlwiRGFuaWVscy1NYWNCb29rLVByby0yLmxvY2FsXCIsXCJyZXVzYWJsZVwiOmZhbHNlLFwidmFsaWRmb3JcIjoxNTc2ODAwMDAsXCJ1dWlkXCI6XCJlMzZkMzkyOS05NWVlLTQyNDQtOTIwZS00NmZiN2Y4MTU3ZDVcIn0iLCJleHAiOiIxNTk1MTc3NTc0In0.gfTpUPLGnxwtvfMH5C0ucWsXBqrhBD_HvCiNH_9zvhFafHMij_ng14K8F-MMLgQoDBloOJukjX8qcki5cFmKKg", :common_name=>"i-7672fe81"})
     end
+
     it 'Returns nil given an invalid CSR' do
       expect(Autosign::Decoder.decode_csr("not_a_csr")).to be_nil
+    end
+
+    it 'Does not raise an error decoding a CSR without a challengePassword' do
+      allow_any_instance_of(OpenSSL::X509::Attribute).to receive(:oid).and_return('notTheOidYouAreLookingFor')
+      expect { Autosign::Decoder.decode_csr(csr) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
Sometimes a CSR doesn't have a challengePassword attribute, valid or not. Previously, an exception would be raised in this circumstance, short-circuiting any follow-on processing of the CSR. This commit ensures an exception won't be raised in this circumstance.