### PR TITLE
Check PE autosign config file path

### DIFF
--- a/lib/autosign/config.rb
+++ b/lib/autosign/config.rb
@@ -42,7 +42,7 @@ module Autosign
       raise 'settings is not a hash' unless settings_param.is_a?(Hash)
 
       # look in the following places for a config file
-      @config_file_paths = ['/etc/autosign.conf', '/usr/local/etc/autosign.conf']
+      @config_file_paths = ['/etc/puppetlabs/puppetserver/autosign.conf', '/etc/autosign.conf', '/usr/local/etc/autosign.conf']
 
       # HOME is unset when puppet runs, so we need to only use it if it's set
       @config_file_paths << File.join(Dir.home, '.autosign.conf') unless ENV['HOME'].nil?


### PR DESCRIPTION
A recent change to puppet-autosign started putting config files for Puppet Enterprise users in /etc/puppetlabs/puppetserver/autosign.conf, but autosign doesn't actually check for a config file there.

This adds that as a path to check. My current understanding is that most autosign users run PE, so I've put it in the first place to check as a minor optimization.

Thanks @reidmv for pointing out this issue.