### PR TITLE
Declare yard a development dependency

### DIFF
--- a/autosign.gemspec
+++ b/autosign.gemspec
@@ -24,6 +24,7 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3')
   s.add_development_dependency('coveralls')
   s.add_development_dependency('pry', '~> 0.10')
+  s.add_development_dependency('yard', '~> 0.9.11')
   s.add_runtime_dependency('gli','~> 2')
   s.add_runtime_dependency('jwt','~> 1')
   s.add_runtime_dependency('iniparse','~> 1')
@@ -31,5 +32,4 @@ spec = Gem::Specification.new do |s|
   s.add_runtime_dependency('json', '>=1')
   s.add_runtime_dependency('deep_merge', '~> 1')
   s.add_runtime_dependency('require_all', '~> 1')
-  s.add_runtime_dependency('yard', '~> 0.9.11')
 end


### PR DESCRIPTION
Previously, yard was declared as a runtime dependency in our gemspec,
though it appears not to be used during runtime.

This moves yard to be a development dependency which reduces the number
of gems required to be installed on consumers' production servers.