### PR TITLE
Fix ARGF.read interprets the certname as a filename and attempts to read it

### DIFF
--- a/bin/autosign-validator
+++ b/bin/autosign-validator
@@ -2,9 +2,6 @@
 require 'autosign'
 require 'logging'
 
-### Read all the arugments https://tickets.puppetlabs.com/browse/SERVER-1116
-argf_read = ARGF.read
-
 ### Start logging
 @logger = Logging.logger['Autosign']
 @logger.level = :warn
@@ -30,11 +27,12 @@ unless ARGV.count == 1
   exit 1
 end
 
-certname = ARGV[0]
+certname = ARGV.shift
 @logger.debug "certname is " + certname
 
 @logger.debug "reading CSR from stdin"
-raw_csr = $stdin.read
+### Read all the arguments https://tickets.puppetlabs.com/browse/SERVER-1116
+raw_csr = ARGF.read
 csr = Autosign::Decoder.decode_csr(raw_csr)
 exit 1 unless csr.is_a?(Hash)
 

--- a/bin/autosign-validator
+++ b/bin/autosign-validator
@@ -2,6 +2,7 @@
 require 'autosign'
 require 'logging'
 
+### Ensure stdin is read https://tickets.puppetlabs.com/browse/SERVER-1116
 raw_csr = $stdin.read
 
 ### Start logging

--- a/bin/autosign-validator
+++ b/bin/autosign-validator
@@ -24,6 +24,9 @@ end
 ### Get Inputs
 unless ARGV.count == 1
   @logger.error "This executable must be called with a certname as the only parameter and with an X509 CSR piped into STDIN"
+
+  ### Read all the arguments https://tickets.puppetlabs.com/browse/SERVER-1116
+  ARGF.read
   exit 1
 end
 

--- a/bin/autosign-validator
+++ b/bin/autosign-validator
@@ -26,7 +26,7 @@ unless ARGV.count == 1
   @logger.error "This executable must be called with a certname as the only parameter and with an X509 CSR piped into STDIN"
 
   ### Read all the arguments https://tickets.puppetlabs.com/browse/SERVER-1116
-  ARGF.read
+  ARGF.read unless ARGF.eof?
   exit 1
 end
 

--- a/bin/autosign-validator
+++ b/bin/autosign-validator
@@ -2,6 +2,8 @@
 require 'autosign'
 require 'logging'
 
+raw_csr = $stdin.read
+
 ### Start logging
 @logger = Logging.logger['Autosign']
 @logger.level = :warn
@@ -24,9 +26,6 @@ end
 ### Get Inputs
 unless ARGV.count == 1
   @logger.error "This executable must be called with a certname as the only parameter and with an X509 CSR piped into STDIN"
-
-  ### Read all the arguments https://tickets.puppetlabs.com/browse/SERVER-1116
-  ARGF.read unless ARGF.eof?
   exit 1
 end
 
@@ -34,8 +33,6 @@ certname = ARGV.shift
 @logger.debug "certname is " + certname
 
 @logger.debug "reading CSR from stdin"
-### Read all the arguments https://tickets.puppetlabs.com/browse/SERVER-1116
-raw_csr = ARGF.read
 csr = Autosign::Decoder.decode_csr(raw_csr)
 exit 1 unless csr.is_a?(Hash)
 


### PR DESCRIPTION
This [commit](https://github.com/danieldreier/autosign/commit/faf96a198aeb643a5b74cdf570498fe33f22f4b8) has broken autosign_validate.

tldr: ARGF.read interprets the certname as a filename and attempts to read it

Example:
cat test-174.bah.csr | /opt/puppetlabs/puppet/bin/autosign-validator test174.bah
Traceback (most recent call last):
        3: from /opt/puppetlabs/puppet/bin/autosign-validator:23:in `<main>'
        2: from /opt/puppetlabs/puppet/bin/autosign-validator:23:in `load'
        1: from /opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/autosign-0.1.3 on/bin/autosign-validator:6:in `<top (required)>'
/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0/gems/autosign-0.1.3/bin/autosign-validator:6:in `read': No such file or directory @ rb_sysopen - test174.bah (Errno::ENOENT)

Detailed Explanation:
According to ARGF(https://ruby-doc.org/core-2.5.0/ARGF.html)
"The arguments passed to your script are stored in the ARGV Array, one argument per element. ARGF assumes that any arguments that aren't filenames have been removed from ARGV"

The first and only argument here is an certname
ARGF.read interprets the certname as a filename and attempts to read it but fails as the file does not exist.

The fix is to use ARGV.shift to pull in the certname and then call ARGF.read.