### PR TITLE
Bump version to 0.1.4 for a Z release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    autosign (0.1.3)
+    autosign (0.1.4)
       deep_merge (~> 1)
       gli (~> 2)
       iniparse (~> 1)

--- a/lib/autosign/version.rb
+++ b/lib/autosign/version.rb
@@ -1,3 +1,3 @@
 module Autosign
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
  * Use [multi_json] to allow a variety of JSON engines to be used, which makes installation easier.
  * Read all of STDIN regardless of whether we’ll use it in order to avoid a [bug in Java 8].
  * Change yard from a runtime dependency to a dev dependency.
  * Security updates for dependencies:
    * Bump ffi from 1.9.10 to 1.9.25
    * Bump yard from 0.9.12 to 0.9.20

[multi_json]: https://github.com/intridea/multi_json
[bug in Java 8]: https://tickets.puppetlabs.com/browse/SERVER-1116