### PR TITLE
Add new rubies to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ before_install: rm Gemfile.lock || true
 cache: bundler
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1.5
-  - 2.2.2
-  - 2.3.0
+  - 2.2.9
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 deploy:
   provider: rubygems
   api_key:


### PR DESCRIPTION
The list of supported rubies is old and needs to be updated.  This adds new rubies to test against.  And removes ruby 2.0 and 2.1.

We should probably wait till a major release to remove support for 2.2, 2.3.