### PR TITLE
require English library for $CHILD_STATUS usage

### DIFF
--- a/lib/autosign/validator/multiplexer.rb
+++ b/lib/autosign/validator/multiplexer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'autosign/validator/validator_base'
+require 'English'
 
 module Autosign
   module Validator


### PR DESCRIPTION
To use CHILD_STATUS, must `require "English"` library.
 
Addresses:
Issue #60 